### PR TITLE
ZipFile: Add support for opening zip files by fd paths

### DIFF
--- a/ojluni/src/main/native/ZipFile.c
+++ b/ojluni/src/main/native/ZipFile.c
@@ -109,7 +109,12 @@ ZipFile_open(JNIEnv *env, jclass cls, jstring name,
                 goto finally;
             }
 #else
-            zfd = JVM_Open(path, flag, 0);
+            if (!strncmp("/proc/self/fd/", path, strlen("/proc/self/fd/")) &&
+                    sscanf(path, "/proc/self/fd/%d", &zfd) == 1) {
+                zfd = dup(zfd);
+            } else {
+                zfd = JVM_Open(path, flag, 0);
+            }
             if (zfd < 0) {
                 throwFileNotFoundException(env, name);
                 goto finally;


### PR DESCRIPTION
In some cases, it can be useful to open and parse zip files that are only available by fd reference. For example, file descriptors of APKs containing files to load may be sent via Binder IPC for clients to use.

Unfortuantely, while it is already possible for StrictJarFile to open APKs by file descriptor, using that API is not an option because our `/proc/self/fd/##` path is passed to DexPathList for use in ClassLoader implementations.

This is necessary for compatibility with Google Play Services' dynamic module system (Dynamite) without weakening the SELinux sandbox to allow other apps to open module APKs from `/data/user_de/0/com.google.android.gms/app_chimera/m`.