### PR TITLE
libcore: Add hooks for Dynamite module support in GmsCompat

### DIFF
--- a/dalvik/src/main/java/dalvik/system/DelegateLastClassLoader.java
+++ b/dalvik/src/main/java/dalvik/system/DelegateLastClassLoader.java
@@ -21,7 +21,9 @@ import sun.misc.CompoundEnumeration;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
+import java.util.function.Function;
 
+import libcore.api.CorePlatformApi;
 import libcore.util.NonNull;
 import libcore.util.Nullable;
 
@@ -38,6 +40,13 @@ import libcore.util.Nullable;
  * </ul>
  */
 public final class DelegateLastClassLoader extends PathClassLoader {
+
+    /**
+     * Pre-constructor librarySearchPath hook for GmsCompat
+     * @hide
+     */
+    @CorePlatformApi
+    public static volatile Function<String, String> librarySearchPathHook;
 
     /**
      * Whether resource loading delegates to the parent class loader. True by default.
@@ -99,7 +108,7 @@ public final class DelegateLastClassLoader extends PathClassLoader {
 
     public DelegateLastClassLoader(@NonNull String dexPath, @Nullable String librarySearchPath,
             @Nullable ClassLoader parent, boolean delegateResourceLoading) {
-        super(dexPath, librarySearchPath, parent);
+        super(dexPath, filterLibrarySearchPath(librarySearchPath), parent);
         this.delegateResourceLoading = delegateResourceLoading;
     }
 
@@ -113,6 +122,12 @@ public final class DelegateLastClassLoader extends PathClassLoader {
         super(dexPath, librarySearchPath, parent, sharedLibraryLoaders);
         // Delegating is the default behavior.
         this.delegateResourceLoading = true;
+    }
+
+    private static String filterLibrarySearchPath(String librarySearchPath) {
+        return librarySearchPathHook == null ?
+                librarySearchPath :
+                librarySearchPathHook.apply(librarySearchPath);
     }
 
     @Override

--- a/mmodules/core_platform_api/api/platform/current-api.txt
+++ b/mmodules/core_platform_api/api/platform/current-api.txt
@@ -585,6 +585,7 @@ package dalvik.system {
 
   public final class DelegateLastClassLoader extends dalvik.system.PathClassLoader {
     ctor public DelegateLastClassLoader(String, String, ClassLoader, ClassLoader[]);
+    field public static volatile java.util.function.Function<java.lang.String,java.lang.String> librarySearchPathHook;
   }
 
   @Deprecated public final class DexFile {
@@ -609,6 +610,10 @@ package dalvik.system {
   @Deprecated public static final class DexFile.OptimizationInfo {
     method @Deprecated public String getReason();
     method @Deprecated public String getStatus();
+  }
+
+  public final class DexPathList {
+    field public static volatile java.util.function.Function<dalvik.system.DexPathList,java.nio.ByteBuffer[]> postConstructorBufferHook;
   }
 
   public class PathClassLoader extends dalvik.system.BaseDexClassLoader {
@@ -758,6 +763,10 @@ package dalvik.system {
 }
 
 package java.io {
+
+  public class File implements java.lang.Comparable<java.io.File> java.io.Serializable {
+    field public static volatile java.util.function.Function<java.io.File,java.lang.Long> lastModifiedHook;
+  }
 
   public final class FileDescriptor {
     method public int getInt$();

--- a/ojluni/src/main/java/java/io/File.java
+++ b/ojluni/src/main/java/java/io/File.java
@@ -26,6 +26,8 @@
 
 package java.io;
 
+import libcore.api.CorePlatformApi;
+
 import java.net.URI;
 import java.net.URL;
 import java.net.MalformedURLException;
@@ -35,6 +37,8 @@ import java.util.ArrayList;
 import java.security.AccessController;
 import java.nio.file.Path;
 import java.nio.file.FileSystems;
+import java.util.function.Function;
+
 import sun.security.action.GetPropertyAction;
 
 // Android-added: Info about UTF-8 usage in filenames.
@@ -160,6 +164,13 @@ public class File
      * The FileSystem object representing the platform's local file system.
      */
     private static final FileSystem fs = DefaultFileSystem.getFileSystem();
+
+    /**
+     * File#lastModified() hook for GmsCompat
+     * @hide
+     */
+    @CorePlatformApi
+    public static volatile Function<File, Long> lastModifiedHook;
 
     /**
      * This abstract pathname's normalized pathname string. A normalized
@@ -935,6 +946,12 @@ public class File
         }
         if (isInvalid()) {
             return 0L;
+        }
+        if (lastModifiedHook != null) {
+            Long lastModified = lastModifiedHook.apply(this);
+            if (lastModified != null) {
+                return lastModified;
+            }
         }
         return fs.getLastModifiedTime(this);
     }


### PR DESCRIPTION
These hooks are necessary for GmsCompat to support Google Play Services' dynamic module system (Dynamite) without weakening the SELinux sandbox to allow other apps to open module APKs from `/data/user_de/0/com.google.android.gms/app_chimera/m`.

To minimize changes in libcore, each hook is a simple interface method call that delegates the actual hook code to GmsCompat in frameworks/base.