### PR TITLE
Changes for Android 12 GMSCompat

### DIFF
--- a/api/module-lib-current.txt
+++ b/api/module-lib-current.txt
@@ -226,6 +226,7 @@ package dalvik.system {
 
   public final class DelegateLastClassLoader extends dalvik.system.PathClassLoader {
     ctor public DelegateLastClassLoader(String, String, ClassLoader, ClassLoader[]);
+    field public static volatile java.util.function.Function<java.lang.String,java.lang.String> librarySearchPathHook;
   }
 
   @Deprecated public final class DexFile {
@@ -242,6 +243,20 @@ package dalvik.system {
   @Deprecated public static final class DexFile.OptimizationInfo {
     method @Deprecated @NonNull public String getReason();
     method @Deprecated @NonNull public String getStatus();
+  }
+
+  public final class DexPathList {
+    ctor public DexPathList(ClassLoader, String);
+    ctor public DexPathList(ClassLoader, String, String, java.io.File);
+    method public void addDexPath(String, java.io.File);
+    method public void addDexPath(String, java.io.File, boolean);
+    method public void addNativePath(java.util.Collection<java.lang.String>);
+    method public Class<?> findClass(String, java.util.List<java.lang.Throwable>);
+    method public String findLibrary(String);
+    method public java.net.URL findResource(String);
+    method public java.util.Enumeration<java.net.URL> findResources(String);
+    method public java.util.List<java.io.File> getNativeLibraryDirectories();
+    field public static volatile java.util.function.Function<dalvik.system.DexPathList,java.nio.ByteBuffer[]> postConstructorBufferHook;
   }
 
   public class PathClassLoader extends dalvik.system.BaseDexClassLoader {
@@ -379,6 +394,10 @@ package dalvik.system {
 }
 
 package java.io {
+
+  public class File implements java.lang.Comparable<java.io.File> java.io.Serializable {
+    field public static volatile java.util.function.Function<java.io.File,java.lang.Long> lastModifiedHook;
+  }
 
   public final class FileDescriptor {
     method public int getInt$();

--- a/dalvik/src/main/java/dalvik/system/DelegateLastClassLoader.java
+++ b/dalvik/src/main/java/dalvik/system/DelegateLastClassLoader.java
@@ -25,7 +25,9 @@ import sun.misc.CompoundEnumeration;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
+import java.util.function.Function;
 
+import libcore.api.CorePlatformApi;
 import libcore.util.NonNull;
 import libcore.util.Nullable;
 
@@ -42,6 +44,14 @@ import libcore.util.Nullable;
  * </ul>
  */
 public final class DelegateLastClassLoader extends PathClassLoader {
+
+    /**
+     * Pre-constructor librarySearchPath hook for GmsCompat
+     * @hide
+     */
+    @SystemApi(client = SystemApi.Client.MODULE_LIBRARIES)
+    @CorePlatformApi(status = CorePlatformApi.Status.STABLE)
+    public static volatile Function<String, String> librarySearchPathHook;
 
     /**
      * Whether resource loading delegates to the parent class loader. True by default.
@@ -103,7 +113,7 @@ public final class DelegateLastClassLoader extends PathClassLoader {
 
     public DelegateLastClassLoader(@NonNull String dexPath, @Nullable String librarySearchPath,
             @Nullable ClassLoader parent, boolean delegateResourceLoading) {
-        super(dexPath, librarySearchPath, parent);
+        super(dexPath, filterLibrarySearchPath(librarySearchPath), parent);
         this.delegateResourceLoading = delegateResourceLoading;
     }
 
@@ -140,6 +150,12 @@ public final class DelegateLastClassLoader extends PathClassLoader {
         super(dexPath, librarySearchPath, parent, sharedLibraryLoaders);
         // Delegating is the default behavior.
         this.delegateResourceLoading = true;
+    }
+
+    private static String filterLibrarySearchPath(String librarySearchPath) {
+        return librarySearchPathHook == null ?
+                librarySearchPath :
+                librarySearchPathHook.apply(librarySearchPath);
     }
 
     @Override

--- a/ojluni/src/main/java/java/io/File.java
+++ b/ojluni/src/main/java/java/io/File.java
@@ -26,6 +26,10 @@
 
 package java.io;
 
+import android.annotation.SystemApi;
+
+import libcore.api.CorePlatformApi;
+
 import java.net.URI;
 import java.net.URL;
 import java.net.MalformedURLException;
@@ -35,6 +39,8 @@ import java.util.ArrayList;
 import java.security.AccessController;
 import java.nio.file.Path;
 import java.nio.file.FileSystems;
+import java.util.function.Function;
+
 import sun.security.action.GetPropertyAction;
 
 // Android-added: Info about UTF-8 usage in filenames.
@@ -160,6 +166,14 @@ public class File
      * The FileSystem object representing the platform's local file system.
      */
     private static final FileSystem fs = DefaultFileSystem.getFileSystem();
+
+    /**
+     * File#lastModified() hook for GmsCompat
+     * @hide
+     */
+    @SystemApi(client = SystemApi.Client.MODULE_LIBRARIES)
+    @CorePlatformApi(status = CorePlatformApi.Status.STABLE)
+    public static volatile Function<File, Long> lastModifiedHook;
 
     /**
      * This abstract pathname's normalized pathname string. A normalized
@@ -933,6 +947,12 @@ public class File
         }
         if (isInvalid()) {
             return 0L;
+        }
+        if (lastModifiedHook != null) {
+            Long lastModified = lastModifiedHook.apply(this);
+            if (lastModified != null) {
+                return lastModified;
+            }
         }
         return fs.getLastModifiedTime(this);
     }

--- a/ojluni/src/main/native/ZipFile.c
+++ b/ojluni/src/main/native/ZipFile.c
@@ -109,7 +109,12 @@ ZipFile_open(JNIEnv *env, jclass cls, jstring name,
                 goto finally;
             }
 #else
-            zfd = JVM_Open(path, flag, 0);
+            if (!strncmp("/proc/self/fd/", path, strlen("/proc/self/fd/")) &&
+                    sscanf(path, "/proc/self/fd/%d", &zfd) == 1) {
+                zfd = dup(zfd);
+            } else {
+                zfd = JVM_Open(path, flag, 0);
+            }
             if (zfd < 0) {
                 throwFileNotFoundException(env, name);
                 goto finally;


### PR DESCRIPTION
```
In some cases, it can be useful to open and parse zip files that are
only available by fd reference. For example, file descriptors of APKs
containing files to load may be sent via Binder IPC for clients to use.

Unfortuantely, while it is already possible for StrictJarFile to open
APKs by file descriptor, using that API is not an option because our
/proc/self/fd/## path is passed to DexPathList for use in ClassLoader
implementations.

This is necessary for compatibility with Google Play Services' dynamic
module system (Dynamite) without weakening the SELinux sandbox to allow
other apps to open module APKs from
/data/user_de/0/com.google.android.gms/app_chimera/m.
```

```
These hooks are necessary for GmsCompat to support Google Play Services'
dynamic module system (Dynamite) without weakening the SELinux sandbox
to allow other apps to open module APKs from
/data/user_de/0/com.google.android.gms/app_chimera/m.

To minimize changes in libcore, each hook is a simple interface method
call that delegates the actual hook code to GmsCompat in
frameworks/base.
```