### PR TITLE
gmscompat: add File.mkdirsFailedHook

### DIFF
--- a/api/module-lib-current.txt
+++ b/api/module-lib-current.txt
@@ -385,6 +385,7 @@ package java.io {
 
   public class File implements java.lang.Comparable<java.io.File> java.io.Serializable {
     field public static java.util.function.ToLongFunction<java.io.File> lastModifiedHook;
+    field public static java.util.function.Consumer<java.io.File> mkdirsFailedHook;
   }
 
   public final class FileDescriptor {


### PR DESCRIPTION
Play Store needs it to get a callback when installation of an app that
uses OBB expansion files fails.