### PR TITLE
gmscompat: don't use "/proc/self/fd" paths for loading Dynamite modules

### DIFF
--- a/dalvik/src/main/java/dalvik/system/DelegateLastClassLoader.java
+++ b/dalvik/src/main/java/dalvik/system/DelegateLastClassLoader.java
@@ -159,7 +159,7 @@ public final class DelegateLastClassLoader extends PathClassLoader {
         BiFunction<String, Boolean, String> hook = modifyClassLoaderPathHook;
         return hook == null ?
                 path :
-                // replace file paths of GMS Dynamite modules with "/proc/self/fd" file descriptor
+                // replace file paths of GMS Dynamite modules with "/gmscompat_fd_%d" file descriptor
                 // references
                 hook.apply(path, nativeLibsPath);
     }

--- a/dalvik/src/main/java/dalvik/system/DexPathList.java
+++ b/dalvik/src/main/java/dalvik/system/DexPathList.java
@@ -377,7 +377,7 @@ public final class DexPathList {
               // We support directories for looking up resources. Looking up resources in
               // directories is useful for running libcore tests.
               elements[elementsPos++] = new Element(file);
-          } else if (file.isFile()) {
+          } else if (file.isFile() || file.getPath().startsWith("/gmscompat_fd_")) {
               String name = file.getName();
 
               DexFile dex = null;

--- a/ojluni/src/main/native/ZipFile.c
+++ b/ojluni/src/main/native/ZipFile.c
@@ -109,8 +109,8 @@ ZipFile_open(JNIEnv *env, jclass cls, jstring name,
                 goto finally;
             }
 #else
-            if (!strncmp("/proc/self/fd/", path, strlen("/proc/self/fd/")) &&
-                    sscanf(path, "/proc/self/fd/%d", &zfd) == 1) {
+            if (!strncmp("/gmscompat_fd_", path, strlen("/gmscompat_fd_")) &&
+                    sscanf(path, "/gmscompat_fd_%d", &zfd) == 1) {
                 zfd = dup(zfd);
             } else {
                 zfd = JVM_Open(path, flag, 0);


### PR DESCRIPTION
dup()-ing fd that is referred to by "/proc/self/fd" path isn't the same
as open()-ing that path. fd that is returned by dup() refers to the same
underlying file description and thus shares position and file status
flags with the original fd.

The ability to pass "/proc/self/fd" path instead of a file path
is an undocumented API on Android, but there are apps that depend on it.