### PR TITLE
add API for enabling Java DCL checks

### DIFF
--- a/api/module-lib-current.txt
+++ b/api/module-lib-current.txt
@@ -225,6 +225,7 @@ package dalvik.system {
   }
 
   public final class DexFile {
+    method public static void enableDynCodeLoadingChecks(int);
     method @Deprecated @NonNull public static dalvik.system.DexFile.OptimizationInfo getDexFileOptimizationInfo(@NonNull String, @NonNull String) throws java.io.FileNotFoundException;
     method @Nullable public static String[] getDexFileOutputPaths(@NonNull String, @NonNull String) throws java.io.FileNotFoundException;
     method @Deprecated public static int getDexOptNeeded(@NonNull String, @NonNull String, @NonNull String, @Nullable String, boolean, boolean) throws java.io.FileNotFoundException, java.io.IOException;

--- a/dalvik/src/main/java/dalvik/system/DexFile.java
+++ b/dalvik/src/main/java/dalvik/system/DexFile.java
@@ -808,4 +808,8 @@ public final class DexFile {
     }
 
     private static native long getStaticSizeOfDexFile(Object cookie);
+
+    /** @hide */
+    @SystemApi(client = MODULE_LIBRARIES)
+    public static native void enableDynCodeLoadingChecks(int flags);
 }


### PR DESCRIPTION
Its implementation is in native ART code.