### PR TITLE
expose ZygoteHooks policy hook for exec spawning

### DIFF
--- a/api/module-lib-current.txt
+++ b/api/module-lib-current.txt
@@ -398,6 +398,7 @@ package dalvik.system {
     method public static void onBeginPreload();
     method public static void onEndPreload(boolean);
     method public static void onEndPreload();
+    method public static void postExecSpawn(int);
     method public static void postForkChild(int, boolean, boolean, String);
     method public static void postForkCommon();
     method public static void postForkSystemServer(int);

--- a/dalvik/src/main/java/dalvik/system/ZygoteHooks.java
+++ b/dalvik/src/main/java/dalvik/system/ZygoteHooks.java
@@ -272,6 +272,24 @@ public final class ZygoteHooks {
     }
 
     /**
+     * Called in an app process started through exec-based spawning.
+     *
+     * <p>The process was not forked from a zygote, so this deliberately avoids
+     * the fork-specific {@link #postForkChild} work. It applies app runtime
+     * policy that normally comes from zygote runtime flags before the app
+     * entrypoint is loaded.
+     *
+     * @param runtimeFlags The flags listed in com.android.internal.os.Zygote
+     *                     passed to the runtime.
+     *
+     * @hide
+     */
+    @SystemApi(client = MODULE_LIBRARIES)
+    public static void postExecSpawn(int runtimeFlags) {
+        nativePostExecSpawn(runtimeFlags);
+    }
+
+    /**
      * Called by the zygote in both the parent and child processes after
      * every fork. In the child process, this method is called after
      * {@code postForkChild}.
@@ -318,6 +336,9 @@ public final class ZygoteHooks {
     private static native void nativePostForkChild(long token, int runtimeFlags,
                                                    boolean isSystemServer, boolean isZygote,
                                                    String instructionSet);
+
+    // Hook for app processes started through exec-based spawning.
+    private static native void nativePostExecSpawn(int runtimeFlags);
 
     private static native boolean nativeZygoteLongSuspendOk();
 }


### PR DESCRIPTION
Changeset: 
- https://github.com/GrapheneOS/platform_art/pull/36
- https://github.com/GrapheneOS/platform_frameworks_base/pull/359
- For tests: https://github.com/GrapheneOS/platform_frameworks_base/pull/358

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7899

Exec-spawned app processes need a framework callable entry point to apply hidden API and test API policy before app code is loaded. This change exposes a narrow module-lib ZygoteHooks.postExecSpawn(int) wrapper that forwards the runtime flags to ART.